### PR TITLE
Add schemaVersion field to AnalysisOutput

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.16</version>
+            <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.cornell.weill.reciter</groupId>
   <artifactId>reciter-dynamodb-model</artifactId>
-  <version>2.0.12</version>
+  <version>2.0.13</version>
   <name>ReCiter-Dynamodb-Model</name>
   <description>A set of classes representing a Dynamodb Model</description>
   <url>https://github.com/wcmc-its/ReCiter-Dynamodb-Model</url>

--- a/src/main/java/reciter/database/dynamodb/model/AnalysisOutput.java
+++ b/src/main/java/reciter/database/dynamodb/model/AnalysisOutput.java
@@ -42,4 +42,6 @@ public class AnalysisOutput {
 	private boolean isUsingS3;
 	@DynamoDBAttribute(attributeName = "reCiterFeature")
 	private ReCiterFeature reCiterFeature;
+	@DynamoDBAttribute(attributeName = "schemaVersion")
+	private String schemaVersion;
 }


### PR DESCRIPTION
## Summary
- Adds a `schemaVersion` string field with `@DynamoDBAttribute` annotation to `AnalysisOutput.java`
- Bumps version from 2.0.12 to 2.0.13
- Backward-compatible: old DynamoDB items without `schemaVersion` deserialize with `null`

## Why
When the Java data model changes (new fields added to `ReCiterFeature`, `Analysis`, `Evidence`, etc.), stale Analysis table entries in DynamoDB fail deserialization (e.g., `DynamoDBMappingException: middle name should not be null`). This field enables ReCiter to compare stored vs. current schema version and auto-invalidate mismatched entries.

## Dependency
- After merge, needs Sonatype release (`mvn release:prepare release:perform`) to publish 2.0.13
- ReCiter PR (wcmc-its/ReCiter#579) depends on this being published

## Test plan
- [ ] Verify `AnalysisOutput` still deserializes old entries (schemaVersion will be null)
- [ ] Verify new entries can store and retrieve schemaVersion

🤖 Generated with [Claude Code](https://claude.com/claude-code)